### PR TITLE
[fix] change tempdir from ~/.myqr to general temporary direcory

### DIFF
--- a/amzqr/amzqr.py
+++ b/amzqr/amzqr.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 import os
+import tempfile
+
 from amzqr.mylibs import theqrmodule
 from PIL import Image
    
@@ -85,11 +87,7 @@ def run(words, version=1, level='H', picture=None, colorized=False, contrast=1.0
         qr.resize((qr.size[0]*3, qr.size[1]*3)).save(qr_name)
         return qr_name
 
-    tempdir = os.path.join(os.path.expanduser('~'), '.myqr')
-    
-    try:
-        if not os.path.exists(tempdir):
-            os.makedirs(tempdir)
+    with tempfile.TemporaryDirectory() as tempdir:
 
         ver, qr_name = theqrmodule.get_qrcode(version, level, words, tempdir)
 
@@ -123,10 +121,3 @@ def run(words, version=1, level='H', picture=None, colorized=False, contrast=1.0
             qr.resize((qr.size[0]*3, qr.size[1]*3)).save(qr_name)
           
         return ver, level, qr_name
-        
-    except:
-        raise
-    finally:
-        import shutil
-        if os.path.exists(tempdir):
-            shutil.rmtree(tempdir) 


### PR DESCRIPTION
Now amzqr uses "~/.myqr" as temporary directory. If there are 2 (or more) processes, then one will remove the temporary directory even if the other is using it. This cause some Exception.
So I fixed it by change tempdir from ~/.myqr to general temporary direcory.

related to #36 