### PR TITLE
fix(sec): upgrade imageio to 2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-imageio==1.5
+imageio==2.6.0
 numpy==1.11.1
 Pillow==8.1.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in imageio 1.5
- [MPS-2022-14946](https://www.oscs1024.com/hd/MPS-2022-14946)


### What did I do？
Upgrade imageio from 1.5 to 2.6.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS